### PR TITLE
fix(open-api): Missing FormatQueryPayloadSchema schema

### DIFF
--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -89,6 +89,7 @@ class SqlLabRestApi(BaseSupersetApi):
     openapi_spec_component_schemas = (
         EstimateQueryCostSchema,
         ExecutePayloadSchema,
+        FormatQueryPayloadSchema,
         QueryExecutionResponseSchema,
         SQLLabBootstrapSchema,
     )


### PR DESCRIPTION
### SUMMARY
- TheFormatQueryPayloadSchema component schema was missing in the open-api spec

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://github.com/user-attachments/assets/c3c7c3f0-3dbd-4fb3-935d-d6e3ebc0946b)


### TESTING INSTRUCTIONS
- Check that FormatQueryPayloadSchema exists in the open-api spec.
